### PR TITLE
Provide default emacs key-bindings for ctrl-left, ctrl-right, and ctrl-default

### DIFF
--- a/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -4863,6 +4863,7 @@ public class LineReaderImpl implements LineReader, Flushable
         bind(emacs, BACKWARD_WORD,                          alt('b'));
         bind(emacs, CAPITALIZE_WORD,                        alt('c'));
         bind(emacs, KILL_WORD,                              alt('d'));
+        bind(emacs, KILL_WORD,                              translate("^[[3;5~")); // ctrl-delete
         bind(emacs, FORWARD_WORD,                           alt('f'));
         bind(emacs, DOWN_CASE_WORD,                         alt('l'));
         bind(emacs, HISTORY_SEARCH_FORWARD,                 alt('n'));
@@ -4872,6 +4873,8 @@ public class LineReaderImpl implements LineReader, Flushable
         bind(emacs, YANK_POP,                               alt('y'));
         bind(emacs, BACKWARD_KILL_WORD,                     alt(del()));
         bindArrowKeys(emacs);
+        bind(emacs, FORWARD_WORD,                           translate("^[[1;5C")); // ctrl-left
+        bind(emacs, BACKWARD_WORD,                          translate("^[[1;5D")); // ctrl-right
         bind(emacs, FORWARD_WORD,                           alt(key(Capability.key_right)));
         bind(emacs, BACKWARD_WORD,                          alt(key(Capability.key_left)));
         bind(emacs, FORWARD_WORD,                           alt(translate("^[[C")));


### PR DESCRIPTION
Xterm-compatible terminals transmit certain weird but recognizable key sequences for ctrl-left, ctrl-right, and ctrl-default.  These should be bound to the "standard" bindings: forward-word, backward-word, and kill-word, as GNU readline (and emacs) does. (There is no special key sequence for ctrl-backspace.)

This patch only handles the emacs bindings. It seems reasonable to do the same for vi - both vicmd and viins.
